### PR TITLE
Fix compatibility with drupal-extension:4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "prefer-stable": true,
   "require": {
     "behat/mink":   "~1.5",
-    "drupal/drupal-extension": "^3.1"
+    "drupal/drupal-extension": "^4.1"
   },
   "autoload": {
     "psr-4": {"DennisDigital\\Behat\\Drupal\\Paragraphs\\": "src"}


### PR DESCRIPTION
The `drupal-extension` has moved on since this was last updated.  Can we get this merged in and updated on Packagist please.

Failing the update on Packagist instructions in the README for adding this repo to the `repositories` section of `composer.json` would suffice.

Cheers,
Gold